### PR TITLE
(feature) Add API documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ yarn.lock
 
 # Databases
 *.sqlite
+
+# Documentation (run 'npm run doc' to build)
+docs/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,12 @@
   "main": "server.js",
   "scripts": {
     "test": "NODE_ENV=test mocha server/spec",
-    "start": "NODE_ENV=dev nodemon server/server.js"
+    "start": "NODE_ENV=dev nodemon server/server.js",
+    "doc": "apidoc -i server/routes -o docs/api"
+  },
+  "apidoc": {
+    "title": "The API for the Piddle bill splitting application",
+    "url": ""
   },
   "repository": {
     "type": "git",

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -4,10 +4,65 @@ const router = express.Router(); // eslint-disable-line
 
 const handler = require('../handlers/apiHandler');
 
-router.get('/bill/:id', (request, response) => {
+/**
+ * @api {get} /api/bill/:id Retrieve a bill
+ * @apiName GetBill
+ * @apiGroup Bill
+ *
+ * @apiParam {string} shortId The short id of the bill.
+ *
+ * @apiSuccess {Object} data Data associated with the bill.
+ * @apiSuccess {string} data.shortId Short id associated with the bill.
+ * @apiSuccess {string} data.description Description of the bill.
+ * @apiSuccess {number} data.tax Tax in local currency.
+ * @apiSuccess {number} data.tip Tip in local currency.
+ * @apiSuccess {Object[]} data.items Items on the bill.
+ * @apiSuccess {number} data.items[].id The id of the item.
+ * @apiSuccess {string} data.items[].description Description of the item.
+ * @apiSuccess {number} data.items[].price Price of the item in local currency.
+ * @apiSuccess {boolean} data.items[].claimed True if a debtor has claimed the item.
+ * @apiSuccess {boolean} data.items[].paid True if the item has been paid for (reserved for future use).
+ * @apiSuccess {Object} data.items[].debtor Person responsible for paying for the item.
+ * @apiSuccess {string} data.items[].debtor.emailAddress The email address of the debtor.
+ * @apiSuccess {string} data.items[].debtor.displayName Name of the debtor to display.
+ * @apiSuccess {Object} data.payer The payer of the bill; presumably who created the bill in the app.
+ * @apiSuccess {string} data.payer.emailAddress Email address of the payer.
+ * @apiSuccess {string} data.payer.displayName Name of the payer to display.
+ * @apiSuccess {string} data.payer.squareId SquareCash www.cash.me 'cashtag' of the payer
+ * @apiSuccess {string} data.payer.paypalId PayPal paypal.me id of the payer.
+ */
+router.get('/bill/:shortId', (request, response) => {
   response.send(500, 'Not implemented');
 });
 
+/**
+ * @api {post} /api/bill Create a bill
+ * @apiName CreateBill
+ * @apiGroup Bill
+ *
+ * @apiParam {string} description Description of the bill.
+ * @apiParam {number} [tax] Tax in local currency associated with the bill.
+ * @apiParam {number} [tip] Tip amount in local currency
+ * @apiParam {Object[]} items Individual items on the bill.
+ * @apiParam {string} items[].description Description of the item.
+ * @apiParam {string} items[].price Price of the item in local currency.
+ * @apiParam {string} payerEmailAddress Email address of the bill payer.
+ *
+ * @apiSuccess {Object} data Data associated with the new bill.
+ * @apiSuccess {string} data.shortId The short id of the bill.
+ *
+ * @apiError {Object} error Error information associated with the bill.
+ * @apiError {string} error.message Human-readable description of the error.
+ *
+ * @apiSuccessExample Success-Response
+ *    HTTP/1.1 201 CREATED
+ *    {
+ *      data: {
+ *        shortId: s5y26
+ *      }
+ *    }
+ *
+ */
 router.post('/bill', handler.saveBill);
 
 module.exports = router;

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -9,30 +9,67 @@ const handler = require('../handlers/apiHandler');
  * @apiName GetBill
  * @apiGroup Bill
  *
+ * @apiPermission user
+ *
  * @apiParam {string} shortId The short id of the bill.
  *
- * @apiSuccess {Object} data Data associated with the bill.
- * @apiSuccess {string} data.shortId Short id associated with the bill.
- * @apiSuccess {string} data.description Description of the bill.
- * @apiSuccess {number} data.tax Tax in local currency.
- * @apiSuccess {number} data.tip Tip in local currency.
- * @apiSuccess {Object[]} data.items Items on the bill.
- * @apiSuccess {number} data.items[].id The id of the item.
- * @apiSuccess {string} data.items[].description Description of the item.
- * @apiSuccess {number} data.items[].price Price of the item in local currency.
- * @apiSuccess {boolean} data.items[].claimed True if a debtor has claimed the item.
- * @apiSuccess {boolean} data.items[].paid True if the item has been paid for (reserved for future use).
- * @apiSuccess {Object} data.items[].debtor Person responsible for paying for the item.
- * @apiSuccess {string} data.items[].debtor.emailAddress The email address of the debtor.
- * @apiSuccess {string} data.items[].debtor.displayName Name of the debtor to display.
- * @apiSuccess {Object} data.payer The payer of the bill; presumably who created the bill in the app.
- * @apiSuccess {string} data.payer.emailAddress Email address of the payer.
- * @apiSuccess {string} data.payer.displayName Name of the payer to display.
- * @apiSuccess {string} data.payer.squareId SquareCash www.cash.me 'cashtag' of the payer
- * @apiSuccess {string} data.payer.paypalId PayPal paypal.me id of the payer.
+ * @apiSuccess (200) {Object} data Data associated with the bill.
+ * @apiSuccess (200) {string} data.shortId Short id associated with the bill.
+ * @apiSuccess (200) {string} data.description Description of the bill.
+ * @apiSuccess (200) {number} data.tax Tax in local currency.
+ * @apiSuccess (200) {number} data.tip Tip in local currency.
+ * @apiSuccess (200) {Object[]} data.items Items on the bill.
+ * @apiSuccess (200) {number} data.items.id The id of the item.
+ * @apiSuccess (200) {string} data.items.description Description of the item.
+ * @apiSuccess (200) {number} data.items.price Price of the item in local currency.
+ * @apiSuccess (200) {boolean} data.items.claimed True if a debtor has claimed the item.
+ * @apiSuccess (200) {boolean} data.items.paid True if the item has been paid for (reserved for future use).
+ * @apiSuccess (200) {Object} data.items.debtor Person responsible for paying for the item.
+ * @apiSuccess (200) {string} data.items.debtor.emailAddress The email address of the debtor.
+ * @apiSuccess (200) {string} data.items.debtor.displayName Name of the debtor to display.
+ * @apiSuccess (200) {Object} data.payer The payer of the bill; presumably who created the bill in the app.
+ * @apiSuccess (200) {string} data.payer.emailAddress Email address of the payer.
+ * @apiSuccess (200) {string} data.payer.displayName Name of the payer to display.
+ * @apiSuccess (200) {string} data.payer.squareId SquareCash www.cash.me 'cashtag' of the payer
+ * @apiSuccess (200) {string} data.payer.paypalId PayPal paypal.me id of the payer.
+ *
+ * @apiSuccessExample Success-Response
+ *    HTTP/1.1 200 OK
+ *    {
+ *      data: {
+ *        shortId: "s5y26",
+ *        description: "Tu Lan lunch",
+ *        tax: 2.46,
+ *        tip: 9.50,
+ *        items: [
+ *          {
+ *            id: 45,
+ *            description: "#27 Dragon Roll",
+ *            price: 10.99,
+ *            claimed: true,
+ *            debtor: {
+ *              emailAddress: "charding@gmail.com",
+ *              displayName: "Carl Harding"
+ *            }
+ *          },
+ *          {
+ *            id: 89,
+ *            description: '#8 Curry Rice',
+ *            price: 6.50,
+ *            claimed: false
+ *          }
+ *        ],
+ *        payer: {
+ *          emailAddress: "sample-payer@gmail.com",
+ *          displayName: "Lindsie Tanya"
+ *          squareId: "$LindsieT",
+ *          paypalId: "LTanya"
+ *        }
+ *      }
+ *    }
  */
-router.get('/bill/:shortId', (request, response) => {
-  response.send(500, 'Not implemented');
+router.get('/bill/:shortId' (request, response) => {
+  response.send(500, "Not implemented");
 });
 
 /**
@@ -40,16 +77,18 @@ router.get('/bill/:shortId', (request, response) => {
  * @apiName CreateBill
  * @apiGroup Bill
  *
- * @apiParam {string} description Description of the bill.
+ * @apiPermission user 
+ *
+ * @apiParam {string} [description] Description of the bill.
  * @apiParam {number} [tax] Tax in local currency associated with the bill.
  * @apiParam {number} [tip] Tip amount in local currency
  * @apiParam {Object[]} items Individual items on the bill.
- * @apiParam {string} items[].description Description of the item.
- * @apiParam {string} items[].price Price of the item in local currency.
+ * @apiParam {string} items.description Description of the item.
+ * @apiParam {string} items.price Price of the item in local currency.
  * @apiParam {string} payerEmailAddress Email address of the bill payer.
  *
- * @apiSuccess {Object} data Data associated with the new bill.
- * @apiSuccess {string} data.shortId The short id of the bill.
+ * @apiSuccess (201) {Object} data Data associated with the new bill.
+ * @apiSuccess (201) {string} data.shortId The short id of the bill.
  *
  * @apiError {Object} error Error information associated with the bill.
  * @apiError {string} error.message Human-readable description of the error.
@@ -58,7 +97,7 @@ router.get('/bill/:shortId', (request, response) => {
  *    HTTP/1.1 201 CREATED
  *    {
  *      data: {
- *        shortId: s5y26
+ *        shortId: "s5y26"
  *      }
  *    }
  *


### PR DESCRIPTION
This PR adds the documentation for the API routes. Authentication routes to come.

Added a command to the package.json and the docs folder to the gitignore.

Run 'npm run doc' to generate the docs in the docs/ directory.
